### PR TITLE
Request microphone permission when recording video

### DIFF
--- a/Source/Helpers/Permissions/YPPermissionCheckable.swift
+++ b/Source/Helpers/Permissions/YPPermissionCheckable.swift
@@ -11,8 +11,10 @@ import UIKit
 internal protocol YPPermissionCheckable {
     func doAfterLibraryPermissionCheck(block: @escaping () -> Void)
     func doAfterCameraPermissionCheck(block: @escaping () -> Void)
+    func doAfterMicrophonePermissionCheck(block: @escaping () -> Void)
     func checkLibraryPermission()
     func checkCameraPermission()
+    func checkMicrophonePermission()
 }
 
 internal extension YPPermissionCheckable where Self: UIViewController {
@@ -36,11 +38,25 @@ internal extension YPPermissionCheckable where Self: UIViewController {
         }
     }
 
+    func doAfterMicrophonePermissionCheck(block: @escaping () -> Void) {
+        YPPermissionManager.checkMicrophonePermissionAndAskIfNeeded(sourceVC: self) { hasPermission in
+            if hasPermission {
+                block()
+            } else {
+                ypLog("Not enough permissions.")
+            }
+        }
+    }
+
     func checkLibraryPermission() {
         YPPermissionManager.checkLibraryPermissionAndAskIfNeeded(sourceVC: self) { _ in }
     }
     
     func checkCameraPermission() {
         YPPermissionManager.checkCameraPermissionAndAskIfNeeded(sourceVC: self) { _ in }
+    }
+
+    func checkMicrophonePermission() {
+        YPPermissionManager.checkMicrophonePermissionAndAskIfNeeded(sourceVC: self) { _ in }
     }
 }

--- a/Source/Helpers/Permissions/YPPermissionManager.swift
+++ b/Source/Helpers/Permissions/YPPermissionManager.swift
@@ -74,4 +74,49 @@ internal struct YPPermissionManager {
             ypLog("Bug. Write to developers please.")
         }
     }
+
+    static func checkMicrophonePermissionAndAskIfNeeded(sourceVC: UIViewController,
+                                                        completion: @escaping YPPermissionManagerCompletion) {
+        if #available(iOS 17, *) {
+            let permission = AVAudioApplication.shared.recordPermission
+
+            switch permission {
+            case .granted:
+                completion(true)
+            case .denied:
+                let alert = YPPermissionDeniedPopup.buildGoToSettingsAlert(cancelBlock: {
+                    completion(false)
+                })
+                sourceVC.present(alert, animated: true, completion: nil)
+            case .undetermined:
+                AVAudioApplication.requestRecordPermission { granted in
+                    DispatchQueue.main.async {
+                        completion(granted)
+                    }
+                }
+            @unknown default:
+                ypLog("Bug. Write to developers please.")
+            }
+        } else {
+            let permission = AVAudioSession.sharedInstance().recordPermission
+
+            switch permission {
+            case .granted:
+                completion(true)
+            case .denied:
+                let alert = YPPermissionDeniedPopup.buildGoToSettingsAlert(cancelBlock: {
+                    completion(false)
+                })
+                sourceVC.present(alert, animated: true, completion: nil)
+            case .undetermined:
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    DispatchQueue.main.async {
+                        completion(granted)
+                    }
+                }
+            @unknown default:
+                ypLog("Bug. Write to developers please.")
+            }
+        }
+    }
 }

--- a/Source/Pages/Video/YPVideoCaptureVC.swift
+++ b/Source/Pages/Video/YPVideoCaptureVC.swift
@@ -110,7 +110,9 @@ internal class YPVideoCaptureVC: UIViewController, YPPermissionCheckable {
     @objc
     func shotButtonTapped() {
         doAfterCameraPermissionCheck { [weak self] in
-            self?.toggleRecording()
+            self?.doAfterMicrophonePermissionCheck {
+                self?.toggleRecording()
+            }
         }
     }
     


### PR DESCRIPTION
YPVideoCaptureHelper supports capturing audio, but YPImagePicker does not request microphone permission.  As a result, videos silently fail to include audio unless the client app preemptively requests audio permission prior to opening YPImagePicker.

In contrast, YPImagePicker does request photo library permission (in YPLibraryVC) and camera permission (in YPCameraVC and YPVideoCaptureVC). With this change, YPVideoCaptureVC also requests microphone permission, standardizing YPImagePicker's behavior across the three permissions.